### PR TITLE
Add daycare environment

### DIFF
--- a/baselines/train/configs.py
+++ b/baselines/train/configs.py
@@ -38,9 +38,11 @@ def get_experiment_config(args, default_config):
         substrate_name = "clean_up"
     elif args.exp == 'territory_rooms':
         substrate_name = "territory__rooms"
+    elif args.exp == 'day_care':
+        substrate_name = "daycare"
     else:
         raise Exception("Please set --exp to be one of ['pd_arena', 'al_harvest', 'clean_up', \
-                        'territory_rooms']. Other substrates are not supported.")
+                        'territory_rooms','daycare']. Other substrates are not supported.")
 
     # Fetch player roles
     player_roles = substrate.get_config(substrate_name).default_player_roles

--- a/baselines/train/run_ray_train.py
+++ b/baselines/train/run_ray_train.py
@@ -54,7 +54,7 @@ def get_cli_args():
   parser.add_argument(
       "--exp",
       type=str,
-      choices = ['pd_arena','al_harvest','clean_up','territory_rooms'],
+      choices = ['pd_arena','al_harvest','clean_up','territory_rooms', 'day_care'],
       default="pd_arena",
       help="Name of the substrate to run",
   )


### PR DESCRIPTION
Add daycare environment. Tested training
`python baselines/train/run_ray_train.py --num_workers 2 --wandb True --exp day_care`

DONE :

- Train under more steps.
- Prove that video is displayed for evaluation.

`python baselines/evaluation/evaluate.py --config_dir /Users/gema/ray_results/day_care/PPO_meltingpot_95fa1_00000_0_2024-03-29_22-23-28 --policies_dir /Users/gema/ray_results/day_care/PPO_meltingpot_95fa1_00000_0_2024-03-29_22-23-28/checkpoint_000009/policies --create_videos=True --video_dir=/Users/gema/ray_results/day_care/PPO_meltingpot_95fa1_00000_0_2024-03-29_22-23-28/ `

[d6e359c192364451b00152e057a0bd22.webm](https://github.com/SoyGema/MARL-Melting-pot/assets/24204714/a3c36dd9-7bb4-4eb9-b839-0a9f81512c8d)

