### PR TITLE
add supported scenarios

### DIFF
--- a/baselines/train/configs.py
+++ b/baselines/train/configs.py
@@ -25,6 +25,17 @@ SUPPORTED_SCENARIOS = [
     'territory__rooms_3',
     'daycare_0',
     'commons_harvest__partnership_0',
+    'commons_harvest__partnership_1',
+    'commons_harvest__partnership_2',
+    'commons_harvest__partnership_3',
+    'commons_harvest__partnership_4',
+    'commons_harvest__partnership_5',
+    'commons_harvest__open_0',
+    'commons_harvest__open_1',
+    'commons_harvest__closed_0',
+    'commons_harvest__closed_1',
+    'commons_harvest__closed_2',
+    'commons_harvest__closed_3',
 ]
 
 IGNORE_KEYS = ['WORLD.RGB', 'INTERACTION_INVENTORIES', 'NUM_OTHERS_WHO_CLEANED_THIS_STEP']


### PR DESCRIPTION
Add common_harvest to the supported scenarios list
We include as many as the paper states for each common_harvest
<img width="1092" alt="Captura de pantalla 2024-04-19 a las 13 24 18" src="https://github.com/SoyGema/MARL-Melting-pot/assets/24204714/8bb3c842-a8b2-4b03-9e3b-7f5d21fe3a92">
<img width="803" alt="CH_closed" src="https://github.com/SoyGema/MARL-Melting-pot/assets/24204714/47b15487-d70c-4e86-8a59-49ea009304a8">
<img width="894" alt="Closed" src="https://github.com/SoyGema/MARL-Melting-pot/assets/24204714/6ded6a9e-7d30-4d55-a819-3a5afdabc8c3">
